### PR TITLE
Batch files through Github LFS API to avoid rate limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "aws-sdk": "^2.662.0",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.6",
+    "lodash.chunk": "^4.2.0",
+    "lodash.flatten": "^4.4.0",
+    "lodash.zipwith": "^4.2.0",
     "mime-types": "^2.1.27",
     "node-fetch": "^2.6.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,6 +345,16 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+lodash.chunk@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
+  integrity sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -359,6 +369,11 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
+
+lodash.zipwith@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.zipwith/-/lodash.zipwith-4.2.0.tgz#afacf03fd2f384af29e263c3c6bda3b80e3f51fd"
+  integrity sha1-r6zwP9LzhK8p4mPDxr2juA4/Uf0=
 
 macos-release@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
When migrating That's My Cake we found the weight of the assets (5000+ images to resolve) was tripping rate limits on the Github LFS API when resolving each file pointer as an individual API call.

This approach instead splits pointers into chunks (currently 50, but configurable) and makes API calls with these batches - also limited to concurrency of 10. The resulting data can still be invoked on the Lambda function at 1000 concurrency so the performance is pretty quick.

Better error catching is also added so any API issues will stop the whole run rather than failing silently and moving on to the next Action step.