### PR TITLE
Change file batching behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "fs-extra": "^9.0.0",
     "glob": "^7.1.6",
     "lodash": "^4.17.21",
-    "mime-types": "^2.1.27",
-    "node-fetch": "^2.6.1"
+    "mime-types": "^2.1.27"
   },
   "devDependencies": {
     "@types/async": "^3.2.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,7 +1415,7 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^2.3.0, node-fetch@^2.6.1:
+node-fetch@^2.3.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
How this Action works:

- Action checks out the repo without downloading any LFS files
- Action batches up the LFS pointer files and resolves them to full S3 URLs in batches of 50 (due to GH API rate limit)
- Entire list of resolved URLs is recombined and fired at the lambda function at max concurrency (1000)
- Each Lambda function invocation receives an individual resolved URL, fetches it from S3, resizes and saves the result back to our bucket

The problem we were seeing is that a long (1 hr +) build was erroring after that hour because the resolved URLs have a short TTL and were going stale - so the lambda function was getting a 403 Forbidden when trying to fetch the file to process.

This change alters the batching behaviour so the files are resolved in chunks and _then_ processed by the lambda before moving on to the next set. This is done in chunks of 50 which is probably far too pessimistic but saves a deeper change and won't add any significant overhead to the overall process time.